### PR TITLE
[interface] Update return failures for connect

### DIFF
--- a/ESP8266/ESP8266.cpp
+++ b/ESP8266/ESP8266.cpp
@@ -56,7 +56,7 @@ bool ESP8266::startup(int mode)
 
 bool ESP8266::reset(void)
 {
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < 3; i++) {
         if (_parser.send("AT+RST")
             && _parser.recv("OK\r\nready")) {
             return true;

--- a/ESP8266Interface.cpp
+++ b/ESP8266Interface.cpp
@@ -61,13 +61,13 @@ int ESP8266Interface::connect()
     if (_esp.get_firmware_version() != ESP8266_VERSION) {
         debug("ESP8266: ERROR: Firmware incompatible with this driver.\
                \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION); 
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_UNSUPPORTED;
     }
     
     _esp.setTimeout(ESP8266_CONNECT_TIMEOUT);
 
     if (!_esp.startup(3)) {
-        return NSAPI_ERROR_DEVICE_ERROR;
+        return NSAPI_ERROR_PARAMETER;
     }
 
     if (!_esp.dhcp(true, 1)) {
@@ -79,7 +79,7 @@ int ESP8266Interface::connect()
     }
 
     if (!_esp.getIPAddress()) {
-        return NSAPI_ERROR_DHCP_FAILURE;
+        return NSAPI_ERROR_NO_ADDRESS;
     }
 
     return NSAPI_ERROR_OK;


### PR DESCRIPTION
This patch updates the return values for the ESP8266Interface when
connect is called so that failures are distinct.

Signed-off-by: Ryan Sherlock <ryan.m.sherlock@gmail.com>